### PR TITLE
FastAPIアプリケーションを拡張し、Ollamaと連携する新しい/generateエンドポイントを追加します。

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OLLAMA_API_URL=http://localhost:11434/api/generate
+LLM_MODEL_NAME=qwen3:8b

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+*.log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,10 @@ description = ""
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "fastapi (>=0.116.1,<0.117.0)"
+    "fastapi (>=0.116.1,<0.117.0)",
+    "httpx (>=0.27.0,<0.28.0)",
+    "python-dotenv (>=1.0.1,<2.0.0)",
+    "uvicorn (>=0.29.0,<0.30.0)",
 ]
 
 [tool.poetry]

--- a/src/template_llm_api/main.py
+++ b/src/template_llm_api/main.py
@@ -1,14 +1,44 @@
+import os
+import httpx
 from fastapi import FastAPI
-from typing import Optional
+from pydantic import BaseModel
+from dotenv import load_dotenv
+
+# .envファイルから環境変数を読み込む
+load_dotenv()
 
 # FastAPIのインスタンスを作成
 app = FastAPI()
+
+# リクエストボディの型を定義
+class GenerateRequest(BaseModel):
+    prompt: str
 
 # ルートエンドポイント（/）に対するGETリクエストのハンドラ
 @app.get("/")
 def read_root():
     return {"message": "Hello, World!"}
 
-@app.get("/items/{item_id}")
-def read_item(item_id: int, q: Optional[str] = None):
-    return {"item_id": item_id, "q": q}
+# /generateエンドポイント（POST）
+@app.post("/generate")
+async def generate(request: GenerateRequest):
+    """
+    Ollama APIにリクエストを送信し、LLMからの応答を返します。
+    """
+    ollama_api_url = os.getenv("OLLAMA_API_URL")
+    llm_model_name = os.getenv("LLM_MODEL_NAME")
+
+    payload = {
+        "model": llm_model_name,
+        "prompt": request.prompt,
+        "stream": False
+    }
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(ollama_api_url, json=payload, timeout=60.0)
+        response.raise_for_status()  # エラーがあれば例外を発生させる
+
+    ollama_response = response.json()
+    print("Ollama APIからのレスポンス:", ollama_response)  # コンソールに出力
+
+    return {"response": ollama_response.get("response")}


### PR DESCRIPTION
主な変更点：
- .envファイルを使用してOllama APIのURLとモデル名を管理
- httpxとpython-dotenvを依存関係に追加
- /generateにPOSTリクエストを処理する非同期APIエンドポイントを実装
- リクエストボディからpromptを受け取り、Ollama APIに送信
- Ollamaからのレスポンスをクライアントに返却